### PR TITLE
Update README with environment setup and deployment notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 
 This project provides a Flask-based API for analyzing marketing messages using persona simulations.
 
+## Configuration
+
+Create a `.env` file in the project root to hold any secrets or settings.  The
+application uses `python-dotenv` so values in this file are loaded
+automatically.  At minimum specify your OpenAI key:
+
+```bash
+cp .env.example .env
+echo "OPENAI_API_KEY=your-openai-key" >> .env
+```
+
+Additional configuration options such as `DEBUG`, `HOST`, `PORT`,
+`CORS_ORIGINS`, and model defaults are defined in `src/config.py`.
+
 ## Running the Application
 
 Install the dependencies listed in `requirements.txt` and start the Flask app:
@@ -10,6 +24,11 @@ Install the dependencies listed in `requirements.txt` and start the Flask app:
 pip install -r requirements.txt
 python src/app.py
 ```
+
+By default this launches the development configuration.  For a production
+deployment switch `config['default']` in `src/config.py` to use
+`ProductionConfig` and run the server with a WSGI container such as
+`gunicorn`.
 
 ## Running Tests
 


### PR DESCRIPTION
## Summary
- show how to create a `.env` file and set `OPENAI_API_KEY`
- describe available configuration options in `src/config.py`
- explain development vs production usage

## Testing
- `pytest -q` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'api_key')*

------
https://chatgpt.com/codex/tasks/task_e_684041938f388333bd4af2468a461c24