### PR TITLE
Persist history with sqlite

### DIFF
--- a/src/utils/history_manager.py
+++ b/src/utils/history_manager.py
@@ -1,11 +1,35 @@
 # src/utils/history_manager.py
 from datetime import datetime
-from .logger import app_logger # Import app_logger
+import json
+import sqlite3
+from .logger import app_logger  # Import app_logger
 
 class HistoryManager:
-    def __init__(self):
-        self._response_history = []
-        app_logger.info("HistoryManager initialized.")
+    def __init__(self, db_path="history.db"):
+        self.db_path = db_path
+        self._connect()
+        self._create_table()
+        app_logger.info("HistoryManager initialized with database %s.", db_path)
+
+    def _connect(self):
+        self.conn = sqlite3.connect(self.db_path, check_same_thread=False)
+        self.conn.row_factory = sqlite3.Row
+        self.cursor = self.conn.cursor()
+
+    def _create_table(self):
+        self.cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT,
+                message TEXT,
+                image INTEGER,
+                personas TEXT,
+                results TEXT
+            )
+            """
+        )
+        self.conn.commit()
 
     def add_entry(self, message, image_data, personas, results):
         entry = {
@@ -15,13 +39,43 @@ class HistoryManager:
             'personas': personas,
             'results': results
         }
-        self._response_history.append(entry)
-        app_logger.info(f"New entry added to history. Total entries: {len(self._response_history)}")
+        self.cursor.execute(
+            "INSERT INTO history (timestamp, message, image, personas, results) VALUES (?, ?, ?, ?, ?)",
+            (
+                entry['timestamp'],
+                entry['message'],
+                1 if entry['image'] else 0,
+                json.dumps(entry['personas']),
+                json.dumps(entry['results'])
+            ),
+        )
+        self.conn.commit()
+        app_logger.info("New entry added to history database.")
 
     def get_history(self):
-        app_logger.info(f"Retrieving full history. {len(self._response_history)} entries found.")
-        return self._response_history
+        self.cursor.execute("SELECT timestamp, message, image, personas, results FROM history")
+        rows = self.cursor.fetchall()
+        history = []
+        for row in rows:
+            history.append(
+                {
+                    'timestamp': row['timestamp'],
+                    'message': row['message'],
+                    'image': bool(row['image']),
+                    'personas': json.loads(row['personas']),
+                    'results': json.loads(row['results']),
+                }
+            )
+        app_logger.info("Retrieving full history. %d entries found.", len(history))
+        return history
 
     def clear_history(self):
-        self._response_history = []
-        app_logger.info("History cleared.") 
+        self.cursor.execute("DELETE FROM history")
+        self.conn.commit()
+        app_logger.info("History cleared from database.")
+
+    def __del__(self):
+        try:
+            self.conn.close()
+        except Exception:
+            pass

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,7 +13,7 @@ class DummyImage:
     def create(self, *args, **kwargs):
         return {'data': [{'url': 'http://example.com/image.png'}]}
 
-dummy_openai = types.SimpleNamespace(chat=DummyChat(), Image=DummyImage())
+dummy_openai = types.SimpleNamespace(chat=DummyChat(), Image=DummyImage(), api_key=None)
 sys.modules.setdefault('openai', dummy_openai)
 
 from src.routes.analyze import create_analyze_blueprint
@@ -27,8 +27,11 @@ def app(monkeypatch):
     monkeypatch.setattr('src.services.persona.generate_persona_response', lambda message, persona_details, model=None, temperature=None: f"response for {persona_details}")
     monkeypatch.setattr('src.services.vision.analyze_image', lambda image_data, persona_details, model=None, temperature=None: "image response")
     monkeypatch.setattr('src.services.vision.analyze_combined', lambda image_data, message, persona_details, model=None, temperature=None: "combined response")
+    monkeypatch.setattr('src.routes.analyze.generate_persona_response', lambda message, persona_details, model=None, temperature=None: f"response for {persona_details}")
+    monkeypatch.setattr('src.routes.analyze.analyze_image', lambda image_data, persona_details, model=None, temperature=None: "image response")
+    monkeypatch.setattr('src.routes.analyze.analyze_combined', lambda image_data, message, persona_details, model=None, temperature=None: "combined response")
 
-    history_manager = HistoryManager()
+    history_manager = HistoryManager(db_path=':memory:')
     flask_app = Flask(__name__)
     flask_app.register_blueprint(create_analyze_blueprint(history_manager))
     flask_app.register_blueprint(create_history_blueprint(history_manager))


### PR DESCRIPTION
## Summary
- persist history entries to sqlite database
- patch tests to use in-memory sqlite
- adjust monkeypatching in tests

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684042a65b908333a57830ffac0fe655